### PR TITLE
[CC-3562] 3DS EMV for frictionless card

### DIFF
--- a/xendit-android/src/main/java/com/xendit/Xendit.java
+++ b/xendit-android/src/main/java/com/xendit/Xendit.java
@@ -752,7 +752,7 @@ public class Xendit {
         NetworkHandler handler = new NetworkHandler<Authentication>().setResultListener(new ResultListener<Authentication>() {
             @Override
             public void onSuccess(Authentication responseObject) {
-                if (responseObject.getAuthenticationTransactionId() == null) {
+                if (responseObject.getAuthenticationTransactionId() == null || responseObject.getStatus().equalsIgnoreCase("VERIFIED") || responseObject.getStatus().equalsIgnoreCase("FAILED")) {
                     // Fallback to 3DS1 flow
                     handleAuthenticatedToken(tokenId, responseObject, tokenCallback);
                 } else {
@@ -812,12 +812,12 @@ public class Xendit {
     }
 
     private void handleAuthenticatedToken(String tokenId, Authentication authenticatedToken, TokenCallback tokenCallback) {
-        if (!authenticatedToken.getStatus().equalsIgnoreCase("VERIFIED")) {
-            registerBroadcastReceiverAuthenticatedToken(tokenCallback);
-            context.startActivity(XenditActivity.getLaunchIntent(context, authenticatedToken));
-        } else {
+        if (authenticatedToken.getStatus().equalsIgnoreCase("VERIFIED") || authenticatedToken.getStatus().equalsIgnoreCase("FAILED")) {
             Token token = new Token(authenticatedToken, tokenId);
             tokenCallback.onSuccess(token);
+        } else {
+            registerBroadcastReceiverAuthenticatedToken(tokenCallback);
+            context.startActivity(XenditActivity.getLaunchIntent(context, authenticatedToken));
         }
     }
 


### PR DESCRIPTION
## Description
1. Handle frictionless that get `VERIFIED` in enrollment step
2. Handle EMV 3DS card that get `FAILED` in enrollment step

## Test
- [x] Frictionless card : 44565300000010005
<img width="300" alt="Screen Shot 2020-12-08 at 17 14 46" src="https://user-images.githubusercontent.com/47877695/101470682-e1acf780-3978-11eb-829c-4839161f4909.png">

- [x] Failed card : 4111111111111111
<img width="310" alt="Screen Shot 2020-12-08 at 17 14 24" src="https://user-images.githubusercontent.com/47877695/101470634-d35edb80-3978-11eb-8200-741561a693c5.png">
