### PR TITLE
[CC-4624] Improve 3ds handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.2.3 (2021-06-10)
+
+- Improve 3ds handling
+
 ## 3.0.0 (2021-02-17)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
-## 3.2.3 (2021-06-10)
+## 3.3.0 (2021-06-10)
+
+Features:
+
+- Return `failure_reason` for FAILED 3DS
+
+Fixes:
 
 - Improve 3ds handling
 

--- a/app/src/main/java/com/xendit/example/models/AuthenticationResponse.java
+++ b/app/src/main/java/com/xendit/example/models/AuthenticationResponse.java
@@ -12,6 +12,7 @@ public class AuthenticationResponse {
     private String status;
     private String masked_card_number;
     private CardInfo card_info;
+    private String failure_reason;
 
     public AuthenticationResponse(Authentication authentication) {
         id = authentication.getId();
@@ -19,5 +20,6 @@ public class AuthenticationResponse {
         status = authentication.getStatus();
         masked_card_number = authentication.getMaskedCardNumber();
         card_info = authentication.getCardInfo();
+        failure_reason = authentication.getFailureReason();
     }
 }

--- a/app/src/main/java/com/xendit/example/models/TokenizationResponse.java
+++ b/app/src/main/java/com/xendit/example/models/TokenizationResponse.java
@@ -13,6 +13,7 @@ public class TokenizationResponse {
     private String masked_card_number;
     private boolean should_3ds;
     private CardInfo card_info;
+    private String failure_reason;
 
     public TokenizationResponse(Token token) {
         id = token.getId();
@@ -21,5 +22,6 @@ public class TokenizationResponse {
         masked_card_number = token.getMaskedCardNumber();
         should_3ds = token.getShould_3DS();
         card_info = token.getCardInfo();
+        failure_reason = token.getFailureReason();
     }
 }

--- a/xendit-android/build.gradle
+++ b/xendit-android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 group 'com.xendit'
-version '3.2.3'
+version '3.3.0'
 
 ext {
     bintrayOrg = 'xendit'

--- a/xendit-android/build.gradle
+++ b/xendit-android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 group 'com.xendit'
-version '3.2.2'
+version '3.2.3'
 
 ext {
     bintrayOrg = 'xendit'

--- a/xendit-android/src/main/java/com/xendit/Models/AuthenticatedToken.java
+++ b/xendit-android/src/main/java/com/xendit/Models/AuthenticatedToken.java
@@ -44,11 +44,15 @@ public class AuthenticatedToken implements HasAuthenticationUrl {
     @SerializedName("environment")
     private String environment;
 
+    @SerializedName("failure_reason")
+    private String failureReason;
+
     private AuthenticatedToken(Parcel in) {
         id = in.readString();
         status = in.readString();
         payerAuthenticationUrl = in.readString();
         maskedCardNumber = in.readString();
+        failureReason = in.readString();
     }
 
     public static final Creator<AuthenticatedToken> CREATOR = new Creator<AuthenticatedToken>() {
@@ -93,6 +97,10 @@ public class AuthenticatedToken implements HasAuthenticationUrl {
         return environment;
     }
 
+    public String getFailureReason() {
+        return failureReason;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -104,6 +112,7 @@ public class AuthenticatedToken implements HasAuthenticationUrl {
         parcel.writeString(status);
         parcel.writeString(payerAuthenticationUrl);
         parcel.writeString(maskedCardNumber);
+        parcel.writeString(failureReason);
     }
 
     @NonNull

--- a/xendit-android/src/main/java/com/xendit/Models/Authentication.java
+++ b/xendit-android/src/main/java/com/xendit/Models/Authentication.java
@@ -36,6 +36,9 @@ public class Authentication implements HasAuthenticationUrl {
     @SerializedName("authentication_transaction_id")
     private String authenticationTransactionId;
 
+    @SerializedName("threeds_version")
+    private String threedsVersion;
+
     protected Authentication(Parcel in) {
         id = in.readString();
         creditCardTokenId = in.readString();
@@ -108,6 +111,10 @@ public class Authentication implements HasAuthenticationUrl {
 
     public String getAuthenticationTransactionId() {
         return authenticationTransactionId;
+    }
+
+    public String getThreedsVersion() {
+        return threedsVersion;
     }
 
     @Override

--- a/xendit-android/src/main/java/com/xendit/Models/Authentication.java
+++ b/xendit-android/src/main/java/com/xendit/Models/Authentication.java
@@ -39,6 +39,9 @@ public class Authentication implements HasAuthenticationUrl {
     @SerializedName("threeds_version")
     private String threedsVersion;
 
+    @SerializedName("failure_reason")
+    private String failureReason;
+
     protected Authentication(Parcel in) {
         id = in.readString();
         creditCardTokenId = in.readString();
@@ -47,6 +50,7 @@ public class Authentication implements HasAuthenticationUrl {
         maskedCardNumber = in.readString();
         requestPayload = in.readString();
         authenticationTransactionId = in.readString();
+        failureReason = in.readString();
     }
 
     public Authentication(Token token) {
@@ -55,6 +59,7 @@ public class Authentication implements HasAuthenticationUrl {
         status = token.getStatus();
         maskedCardNumber = token.getMaskedCardNumber();
         card_info = token.getCardInfo();
+        failureReason = token.getFailureReason();
     }
 
     @Override
@@ -66,6 +71,7 @@ public class Authentication implements HasAuthenticationUrl {
         dest.writeString(maskedCardNumber);
         dest.writeString(requestPayload);
         dest.writeString(authenticationTransactionId);
+        dest.writeString(failureReason);
     }
 
     @Override
@@ -115,6 +121,10 @@ public class Authentication implements HasAuthenticationUrl {
 
     public String getThreedsVersion() {
         return threedsVersion;
+    }
+
+    public String getFailureReason() {
+        return failureReason;
     }
 
     @Override

--- a/xendit-android/src/main/java/com/xendit/Models/Token.java
+++ b/xendit-android/src/main/java/com/xendit/Models/Token.java
@@ -13,6 +13,7 @@ public class Token {
     private String masked_card_number;
     private Boolean should_3ds;
     private CardInfo card_info;
+    private String failure_reason;
 
     public Token(AuthenticatedToken authentication) {
         this.id = authentication.getId();
@@ -22,6 +23,7 @@ public class Token {
         this.masked_card_number = authentication.getMaskedCardNumber();
         this.card_info = authentication.getCardInfo();
         this.should_3ds = true;
+        this.failure_reason = authentication.getFailureReason();
     }
 
     public Token(AuthenticatedToken authentication, ThreeDSRecommendation rec) {
@@ -32,6 +34,7 @@ public class Token {
         this.masked_card_number = authentication.getMaskedCardNumber();
         this.should_3ds = rec.getShould_3DS();
         this.card_info = authentication.getCardInfo();
+        this.failure_reason = authentication.getFailureReason();
     }
 
     public Token(Authentication authenticatedToken) {
@@ -41,6 +44,7 @@ public class Token {
         this.should_3ds = true;
         this.masked_card_number = authenticatedToken.getMaskedCardNumber();
         this.card_info = authenticatedToken.getCardInfo();
+        this.failure_reason = authenticatedToken.getFailureReason();
     }
 
     public Token(Authentication authenticatedToken, String tokenId) {
@@ -50,6 +54,7 @@ public class Token {
         this.should_3ds = true;
         this.masked_card_number = authenticatedToken.getMaskedCardNumber();
         this.card_info = authenticatedToken.getCardInfo();
+        this.failure_reason = authenticatedToken.getFailureReason();
     }
 
     public String getId() {
@@ -67,6 +72,8 @@ public class Token {
     public Boolean getShould_3DS() { return should_3ds; }
 
     public CardInfo getCardInfo() { return card_info; }
+
+    public String getFailureReason() { return failure_reason; }
 
     @Deprecated
     public AuthenticatedToken getAuthentication() {

--- a/xendit-android/src/main/java/com/xendit/Xendit.java
+++ b/xendit-android/src/main/java/com/xendit/Xendit.java
@@ -827,7 +827,7 @@ public class Xendit {
             @Override
             public void onSuccess(Authentication responseObject) {
                 if (responseObject.getStatus().equalsIgnoreCase("VERIFIED") || !is3ds2Version(responseObject.getThreedsVersion())) {
-                    // Authentication completed
+                    // Authentication completed or 3DS 1.0 transaction
                     handleAuthenticatedToken(tokenId, responseObject, tokenCallback);
                 }
                 else if (

--- a/xendit-android/src/main/java/com/xendit/Xendit.java
+++ b/xendit-android/src/main/java/com/xendit/Xendit.java
@@ -78,7 +78,7 @@ import static com.xendit.Tracker.SnowplowTrackerBuilder.getTracker;
 public class Xendit {
 
     private static final String TAG = "Xendit";
-    private static final String PRODUCTION_XENDIT_BASE_URL = "https://api.xendit.co";
+    private static final String PRODUCTION_XENDIT_BASE_URL = "https://api-staging.xendit.co";
     private static final String CREATE_CREDIT_CARD_URL = PRODUCTION_XENDIT_BASE_URL + "/credit_card_tokens";
     private static final String CREATE_CREDIT_CARD_TOKEN_URL = PRODUCTION_XENDIT_BASE_URL + "/v2/credit_card_tokens";
     private static final String GET_3DS_URL = PRODUCTION_XENDIT_BASE_URL + "/3ds_bin_recommendation";
@@ -909,7 +909,11 @@ public class Xendit {
     }
 
     private boolean is3ds2Version(String version) {
-        return "2.0".equals(version);
+        if (version != null) {
+            int currentMajorVersion = Integer.parseInt(version.substring(0, 1));
+            return currentMajorVersion >= 2;
+        }
+        return false;
     }
 
     private void create3ds2Authentication(final String tokenId, final String environment, final String jwt, final String amount, final String currency, final TokenCallback tokenCallback) {

--- a/xendit-android/src/main/java/com/xendit/Xendit.java
+++ b/xendit-android/src/main/java/com/xendit/Xendit.java
@@ -826,7 +826,7 @@ public class Xendit {
         NetworkHandler handler = new NetworkHandler<Authentication>().setResultListener(new ResultListener<Authentication>() {
             @Override
             public void onSuccess(Authentication responseObject) {
-                if (responseObject.getStatus().equalsIgnoreCase("VERIFIED")) {
+                if (responseObject.getStatus().equalsIgnoreCase("VERIFIED") || !is3ds2Version(responseObject.getThreedsVersion())) {
                     // Authentication completed
                     handleAuthenticatedToken(tokenId, responseObject, tokenCallback);
                 }

--- a/xendit-android/src/main/java/com/xendit/Xendit.java
+++ b/xendit-android/src/main/java/com/xendit/Xendit.java
@@ -887,7 +887,9 @@ public class Xendit {
     }
 
     private void handle3ds1Tokenization(AuthenticatedToken authentication, TokenCallback tokenCallback) {
-        if (!authentication.getStatus().equalsIgnoreCase("VERIFIED")) {
+        if (authentication.getStatus().equalsIgnoreCase("FAILED")) {
+            tokenCallback.onSuccess(new Token(authentication));
+        } else if (!authentication.getStatus().equalsIgnoreCase("VERIFIED")) {
             registerBroadcastReceiver(tokenCallback);
             context.startActivity(XenditActivity.getLaunchIntent(context, authentication));
         } else { //for multi token

--- a/xendit-android/src/main/java/com/xendit/Xendit.java
+++ b/xendit-android/src/main/java/com/xendit/Xendit.java
@@ -78,7 +78,7 @@ import static com.xendit.Tracker.SnowplowTrackerBuilder.getTracker;
 public class Xendit {
 
     private static final String TAG = "Xendit";
-    private static final String PRODUCTION_XENDIT_BASE_URL = "https://api-staging.xendit.co";
+    private static final String PRODUCTION_XENDIT_BASE_URL = "https://api.xendit.co";
     private static final String CREATE_CREDIT_CARD_URL = PRODUCTION_XENDIT_BASE_URL + "/credit_card_tokens";
     private static final String CREATE_CREDIT_CARD_TOKEN_URL = PRODUCTION_XENDIT_BASE_URL + "/v2/credit_card_tokens";
     private static final String GET_3DS_URL = PRODUCTION_XENDIT_BASE_URL + "/3ds_bin_recommendation";


### PR DESCRIPTION
## Description
1. Only perform the retry for 3DS 2.0 transaction.
Not perform retry for 3DS 1.0 transaction -> [splunk]( https://splunk.tidnex.com/en-US/app/search/search?q=search%2060bf27c101380200199df3e0%20%7C%20spath%20message%20%7C%20search%20message%3D%22Outgoing%20response%22%7C%20spath%20service%20%7C%20search%20service%3D%22xendit-cc-gateway%22&display.page.search.mode=fast&dispatch.sample_ratio=1&earliest=-4h%40m&latest=now&sid=1623140307.279687)
2. Handle failed transaction on tokenization step (Bypassed Authentication test case)
![WhatsApp Image 2021-06-08 at 16 33 01](https://user-images.githubusercontent.com/47877695/121161516-463d0680-c877-11eb-9505-4180e1b64c0a.jpeg)

MIGS_DIRECT transaction
![WhatsApp Image 2021-06-08 at 16 33 04](https://user-images.githubusercontent.com/47877695/121161584-5523b900-c877-11eb-8807-abac30784a5c.jpeg)


Reference:
full test cases -> https://xendit.atlassian.net/wiki/spaces/CA/pages/2027815175/Staging%2Btest%2B3DS%2BHandling%2BImprovement