### PR TITLE
Update gradle to version 6.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip


### PR DESCRIPTION
Update gradle to version 6.3

Previously we got this error while publishing the new version of the SDK
![Screen Shot 2021-06-11 at 14 07 47](https://user-images.githubusercontent.com/47877695/121645443-690d2c00-cabe-11eb-9365-5ef8083215d6.png)
