### PR TITLE
Cc 8198/add store cvn method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Feat: Added storeCVN test page
 - Bug: Bug fix for validation on createAuthentication method
 
-## NOTE: 3.4.2 - 3.7.0 is being skipped due to inconsistency github release tag version with sdk version. Starting on 3.8.0 these 2 version are sync.
+## NOTE: Github tag from 3.4.2 - 3.7.0 is being skipped due to inconsistency github release tag version with sdk version. Starting on 3.8.0 github release tag and xendit-android-sdk package version are in sync.
 
 ## 3.4.2 (2021-09-15)
 - Updated Cardinal Commerce Library credentials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Feat: Added storeCVN method for caching cvn on subsequent multi-use token purpose
 - Feat: Added storeCVN test page
 - Bug: Bug fix for validation on createAuthentication method
+- Chore: Bump up API version from 28 to 30.
 
 ## NOTE: Github tag from 3.4.2 - 3.7.0 is being skipped due to inconsistency github release tag version with sdk version. Starting on 3.8.0 github release tag and xendit-android-sdk package version are in sync.
 

--- a/README.md
+++ b/README.md
@@ -31,24 +31,24 @@ Maven:
 <dependency>
   <groupId>com.xendit</groupId>
   <artifactId>xendit-android</artifactId>
-  <version>3.7.0</version>
+  <version>3.8.0</version>
   <type>pom</type>
 </dependency>
 ```
 
 Gradle:
 ```
-compile 'com.xendit:xendit-android:3.7.0'
+compile 'com.xendit:xendit-android:3.8.0'
 ```
 
 Ivy:
 ```
-<dependency org='com.xendit' name='xendit-android' rev='3.7.0'>
+<dependency org='com.xendit' name='xendit-android' rev='3.8.0'>
   <artifact name='xendit-android' ext='pom' ></artifact>
 </dependency>
 ```
 
-For more information, visit https://central.sonatype.dev/artifact/com.xendit/xendit-android/3.7.0/versions
+For more information, visit https://central.sonatype.dev/artifact/com.xendit/xendit-android/3.8.0/versions
 
 **Note**:
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.xendit.example"
-        targetSdkVersion 28
+        targetSdkVersion 30
+
+
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/xendit-android/build.gradle
+++ b/xendit-android/build.gradle
@@ -31,10 +31,10 @@ ext {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
This PR change scope is:
- Chore: Bump up API version from 28 to 30.

Related with https://github.com/xendit/xendit-sdk-android/pull/97
- Feat: Added storeCVN method for caching cvn on subsequent multi-use token purpose
- Feat: Added storeCVN test page
- Bug: Bug fix for validation on createAuthentication method


Test result attached in JIRA tickets.