### PR TITLE
chore: update to Android SDK version 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 4.0.0 (2024-01-22)
+- Update to use Andriod API Version 34 (Android 14)
+
 ## 3.8.5 (2023-07-04)
 - Chore: Upgrade sentry-android to 6.24.0
 

--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ Maven:
 <dependency>
   <groupId>com.xendit</groupId>
   <artifactId>xendit-android</artifactId>
-  <version>3.8.5</version>
+  <version>4.0.0</version>
   <type>pom</type>
 </dependency>
 ```
 
 Gradle:
 ```
-compile 'com.xendit:xendit-android:3.8.5'
+compile 'com.xendit:xendit-android:4.0.0'
 ```
 
 Ivy:
 ```
-<dependency org='com.xendit' name='xendit-android' rev='3.8.5'>
+<dependency org='com.xendit' name='xendit-android' rev='4.0.0'>
   <artifact name='xendit-android' ext='pom' ></artifact>
 </dependency>
 ```

--- a/xendit-android/build.gradle
+++ b/xendit-android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 group 'com.xendit'
-version '3.8.5'
+version '4.0.0'
 
 ext {
     bintrayOrg = 'xendit'
@@ -36,7 +36,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
         versionCode 1
-        versionName '3.8.5'
+        versionName '4.0.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {


### PR DESCRIPTION
Related with https://github.com/xendit/xendit-sdk-android/pull/110
Bumping up the sdk version number