### PR TITLE
Fix: Potential race conditions when closing activities with pending operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 4.2.1 (2024-11-20)
+- Enhance: Moved finish() call to Handler to ensure proper UI thread execution and prevent memory leaks
+- Fix: Potential race conditions when closing activities with pending operations
+
 ## 4.2.0 (2024-08-06)
 - Feat: Added card holder information in create token and create authentication
 

--- a/README.md
+++ b/README.md
@@ -31,24 +31,24 @@ Maven:
 <dependency>
   <groupId>com.xendit</groupId>
   <artifactId>xendit-android</artifactId>
-  <version>4.2.0</version>
+  <version>4.2.1</version>
   <type>pom</type>
 </dependency>
 ```
 
 Gradle:
 ```
-compile 'com.xendit:xendit-android:4.2.0'
+compile 'com.xendit:xendit-android:4.2.1'
 ```
 
 Ivy:
 ```
-<dependency org='com.xendit' name='xendit-android' rev='4.2.0'>
+<dependency org='com.xendit' name='xendit-android' rev='4.2.1'>
   <artifact name='xendit-android' ext='pom' ></artifact>
 </dependency>
 ```
 
-For more information, visit https://central.sonatype.com/artifact/com.xendit/xendit-android/4.2.0/versions
+For more information, visit https://central.sonatype.com/artifact/com.xendit/xendit-android/4.2.1/versions
 
 **Note**:
 

--- a/xendit-android/build.gradle
+++ b/xendit-android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 group 'com.xendit'
-version '4.2.0'
+version '4.2.1'
 
 ext {
     bintrayOrg = 'xendit'
@@ -37,7 +37,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
         versionCode 1
-        versionName '4.2.0'
+        versionName '4.2.1'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/xendit-android/src/main/java/com/xendit/XenditActivity.java
+++ b/xendit-android/src/main/java/com/xendit/XenditActivity.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.View;
 import android.webkit.CookieManager;
 import android.webkit.WebChromeClient;
@@ -94,8 +95,15 @@ public class XenditActivity extends Activity {
 
         @android.webkit.JavascriptInterface
         public void postMessage(String message) {
-            sendBroadcastReceiver(message);
-            finish();
+            Handler handler = new Handler();
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    sendBroadcastReceiver(message);
+
+                    finish();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
- Moved finish() call to Handler to ensure proper UI thread execution and prevent memory leaks

Thread discussion: [here](https://xendit.slack.com/archives/CPFV473FE/p1732092534812029?thread_ts=1731912630.135909&cid=CPFV473FE)