### PR TITLE
fix: Handle 3DS authentication edge case and version tracking

### DIFF
--- a/xendit-android/src/main/java/com/xendit/Xendit.java
+++ b/xendit-android/src/main/java/com/xendit/Xendit.java
@@ -75,7 +75,6 @@ public class Xendit {
     private static final String GET_3DS_URL = PRODUCTION_XENDIT_BASE_URL + "/3ds_bin_recommendation";
     private static final String DSN_SERVER = "https://7190a1331444434eb6aed7b5a8d776f0@o30316.ingest.sentry.io/6314580";
     private static final String CLIENT_IDENTIFIER = "Xendit Android SDK";
-    private static final String CLIENT_API_VERSION = "2.0.0";
     private static final String CLIENT_TYPE = "SDK";
     static final String ACTION_KEY = "ACTION_KEY";
 
@@ -1499,7 +1498,7 @@ public class Xendit {
         }
         request.addHeader("Authorization", basicAuthCredentials.replace("\n", ""));
         request.addHeader("x-client-identifier", CLIENT_IDENTIFIER);
-        request.addHeader("client-version", CLIENT_API_VERSION);
+        request.addHeader("client-version", BuildConfig.VERSION_NAME);
         request.addHeader("client-type", CLIENT_TYPE);
         return request;
     }

--- a/xendit-android/src/main/java/com/xendit/XenditActivity.java
+++ b/xendit-android/src/main/java/com/xendit/XenditActivity.java
@@ -13,8 +13,8 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
-
 import com.xendit.Models.HasAuthenticationUrl;
+import com.xendit.utils.Auth3DSEventValidator;
 
 /**
  * Created by Sergey on 3/23/17.
@@ -99,9 +99,10 @@ public class XenditActivity extends Activity {
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    sendBroadcastReceiver(message);
-
-                    finish();
+                    if (Auth3DSEventValidator.is3DSResultEventFromXendit(message, XenditActivity.this)) {
+                        sendBroadcastReceiver(message);
+                        finish();
+                    }
                 }
             });
         }

--- a/xendit-android/src/main/java/com/xendit/utils/Auth3DSEventValidator.java
+++ b/xendit-android/src/main/java/com/xendit/utils/Auth3DSEventValidator.java
@@ -1,0 +1,43 @@
+package com.xendit.utils;
+
+import android.content.Context;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.xendit.R;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Auth3DSEventValidator {
+  private static final String ID_FIELD = "id";
+  private static final String STATUS_FIELD = "status";
+
+  private Auth3DSEventValidator() {
+    // Private constructor to prevent instantiation
+  }
+
+  public static boolean is3DSResultEventFromXendit(String message, Context context) {
+    if (message.isEmpty()) return false;
+
+    return isValidJsonMessage(message) || isKnownErrorMessage(message, context);
+  }
+
+  private static boolean isValidJsonMessage(String message) {
+    try {
+      Map<String, Object> messageInJson = new Gson().fromJson(
+          message,
+          new TypeToken<HashMap<String, Object>>() {}.getType()
+      );
+
+      // A valid 3ds callback payload from Xendit, should contain required fields: id and status.
+      return messageInJson.get(ID_FIELD) != null && messageInJson.get(STATUS_FIELD) != null;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static boolean isKnownErrorMessage(String message, Context context) {
+    return message.equals(context.getString(R.string.create_token_error_validation)) ||
+        message.equals(context.getString(R.string.tokenization_error));
+  }
+
+}


### PR DESCRIPTION
- Fix premature webview dismissal caused by unexpected callback responses before 3DS OTP authentication
- Correct version name tracking implementation



Ticket [#1751684](https://xendit.slack.com/archives/C06L0DLT48Z/p1736924955506139)